### PR TITLE
docs: document theme templates parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Lean LMS for WordPress with CPT-based Courses/Lessons and custom-table Enrollmen
 - WooCommerce enrollment
 - BuddyBoss-friendly templates
 - Modular architecture with per-module migrations
+- Theme-ready templates for Courses: `archive-course.html` and `single-course.html` mirror the default WordPress theme so course archives and single course pages match the site's styling.
 
 ## Dev
 composer dump-autoload


### PR DESCRIPTION
## Summary
- note that `archive-course.html` and `single-course.html` now mirror the default WordPress theme for consistent styling

## Testing
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68c14c7b95b08332ae937add9caeff17